### PR TITLE
Add prefetch config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ These options can be set via the environment variable -e flag:
 - **CACHE_MIN_TTL**: The time to live (TTL) value lower bound, in seconds. If more than an hour could easily give trouble due to stale data. (Default: "0", Possible Values: "<integer>")
 - **CACHE_MAX_TTL**: The time to live (TTL) value cap for RRsets and messages in the cache. Items are not cached for longer. In seconds. (Default: "86400", Possible Values: "<integer>")
 - **CACHE_MAX_NEGATIVE_TTL**: The time to live (TTL) value cap for negative responses in the cache. (Default: "3600", Possible Values: "<integer>")
+- **PREFETCH**: Enable to automatically re-fetch cached records before they expire. (Default: "no", Possible Values: "yes, no")
 - **HIDE_IDENTITY**: Enable to not answer id.server and hostname.bind queries. (Default: "no", Possible Values: "yes, no")
 - **HIDE_VERSION**: Enable to not answer version.server and version.bind queries. (Default: "no", Possible Values: "yes, no")
 - **STATISTICS_INTERVAL**: print statistics to the log (for every thread) every N seconds. (Default: "0", Possible Values: "0, 1")

--- a/assets/unbound.conf
+++ b/assets/unbound.conf
@@ -339,7 +339,7 @@ server:
 	# do-not-query-localhost: yes
 
 	# if yes, perform prefetching of almost expired message cache entries.
-	# prefetch: no
+	prefetch: {{PREFETCH}}
 
 	# if yes, perform key lookups adjacent to normal lookups.
 	# prefetch-key: no

--- a/start.sh
+++ b/start.sh
@@ -15,6 +15,7 @@ RRSET_CACHE_SIZE=${RRSET_CACHE_SIZE:-4m}
 CACHE_MIN_TTL=${CACHE_MIN_TTL:-0}
 CACHE_MAX_TTL=${CACHE_MAX_TTL:-86400}
 CACHE_MAX_NEGATIVE_TTL=${CACHE_MAX_NEGATIVE_TTL:-3600}
+PREFETCH=${PREFTECH:-no}
 HIDE_IDENTITY=${HIDE_IDENTITY:-no}
 HIDE_VERSION=${HIDE_VERSION:-no}
 STATISTICS_INTERVAL=${STATISTICS_INTERVAL:-0}
@@ -38,6 +39,7 @@ sed 's/{{RRSET_CACHE_SIZE}}/'"${RRSET_CACHE_SIZE}"'/' -i /usr/local/etc/unbound/
 sed 's/{{CACHE_MIN_TTL}}/'"${CACHE_MIN_TTL}"'/' -i /usr/local/etc/unbound/unbound.conf
 sed 's/{{CACHE_MAX_TTL}}/'"${CACHE_MAX_TTL}"'/' -i /usr/local/etc/unbound/unbound.conf
 sed 's/{{CACHE_MAX_NEGATIVE_TTL}}/'"${CACHE_MAX_NEGATIVE_TTL}"'/' -i /usr/local/etc/unbound/unbound.conf
+sed 's/{{PREFETCH}}/'"${PREFETCH}"'/' -i /usr/local/etc/unbound/unbound.conf
 sed 's/{{HIDE_IDENTITY}}/'"${HIDE_IDENTITY}"'/' -i /usr/local/etc/unbound/unbound.conf
 sed 's/{{HIDE_VERSION}}/'"${HIDE_VERSION}"'/' -i /usr/local/etc/unbound/unbound.conf
 sed 's/{{STATISTICS_INTERVAL}}/'"${STATISTICS_INTERVAL}"'/' -i /usr/local/etc/unbound/unbound.conf


### PR DESCRIPTION
This patch exposes the prefetch config option of unbound, allowing to
enable prefetching if it's considered useful and improving cache
utilisation and response times.

Having the DNS server prefetching the most commonly used DNS requests
and keeping them warm in cache, will help to reduce the time to answer
common requests.